### PR TITLE
READMEに開発用のコマンドを追記する

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
   "repository": "git@github.com:masuP9/content-who-parents.git",
   "author": "masuP9 <masuP9@gmail.com>",
   "license": "MIT",
-  "engines": {
-    "node": ">=12"
-  },
-  "engineStrict": true,
   "scripts": {
     "build:prod": "NODE_ENV=production eleventy",
     "build": "eleventy",


### PR DESCRIPTION
- READMEに開発用のコマンドを追記した
- ~package.json で利用するNode.jsのバージョンを明記した~

package.json をいじるとビルドがコケるのでやめにしました。

確認お願いいたします