### PR TITLE
/parenting-who でアクセスした場合のリンク切れを対応する

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,6 +16,10 @@ module.exports = function (eleventyConfig) {
     return dayjs(v).format("YYYY-MM-DDTHH:mmZ");
   });
 
+  // Nunjucks Shortcode
+  eleventyConfig.addNunjucksShortcode("baseTag", (v) => {
+    return process.env.NODE_ENV === "production" ? `<base href="${v}">` : "";
+  });
   return {
     dir: { input: "src", output: "docs" },
     passthroughFileCopy: true,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -20,6 +20,11 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addNunjucksShortcode("baseTag", (v) => {
     return process.env.NODE_ENV === "production" ? `<base href="${v}">` : "";
   });
+
+  eleventyConfig.addNunjucksShortcode("unsslize", (v) => {
+    return v.replace("https:", "http:");
+  });
+
   return {
     dir: { input: "src", output: "docs" },
     passthroughFileCopy: true,

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,10 +1,12 @@
 ---
 date: Last Modified
+url: https://covid-19-act.jp/parenting-who/
 ---
 <!DOCTYPE html>
 <html lang="ja">
 
   <head>
+    {% baseTag url %}
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>新型コロナウイルスから子どもの心を守る。WHOから世界中の保護者たちへ。</title>

--- a/src/index.njk
+++ b/src/index.njk
@@ -15,13 +15,13 @@ url: https://covid-19-act.jp/parenting-who/
     <meta name="description" content="急な環境の変化や世の中の物々しい雰囲気によって強いストレスを感じたり、不安定になったお子さんとどう接すれば良いのか、悩んでいらっしゃる保護者の方々のために。"/>
     <meta property="og:title" content="新型コロナウイルスから子どもの心を守る。WHOから世界中の保護者たちへ。"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:url" content="https://covid-19-act.jp/parenting-who/"/>
-    <meta property="og:image" content="http://covid-19-act.jp/parenting-who/illustrations/OGP.jpg"/>
-    <meta property="og:image:secure_url" content="https://covid-19-act.jp/parenting-who/illustrations/OGP.jpg"/>
+    <meta property="og:url" content="{{ url }}"/>
+    <meta property="og:image" content="{% unsslize url %}image/OGP.png">
+    <meta property="og:image:secure_url" content="{{ url }}illustrations/OGP.jpg"/>
     <meta property="og:image:width" content="1200"/>
     <meta property="og:image:height" content="630"/>
     <meta property="og:image:alt" content="イラスト：両親と二人のこどもが微笑んでいる。家族を波括弧が囲んでいる。"/>
-    <link rel="canonical" href="https://covid-19-act.jp/parenting-who/"/>
+    <link rel="canonical" href="{{ url }}"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:title" content="新型コロナウイルスから子どもの心を守る。WHOから世界中の保護者たちへ。">
     <meta property="og:description" content="急な環境の変化や世の中の物々しい雰囲気によって強いストレスを感じたり、不安定になったお子さんとどう接すれば良いのか、悩んでいらっしゃる保護者の方々のために。"/>


### PR DESCRIPTION
Netlify が Trailing Slash をデフォルトで設定しているため 、本番URLの末尾スラッシュをなしにした `https://covid-19-act.jp/parenting-who` でアクセスしても `~/parenting-who/index.html` に 200 Rewrite されてリンク切れしません。

しかし、ドキュメント内のアセットやリンクのパスが相対パス指定なので、末尾スラッシュなしでアクセスした場合に下記のような不整合が生じ、アセットファイルが軒並み 404 になってしまいます。

- ドキュメントのURL： `https://covid-19-act.jp/parenting-who/`
- ドキュメント内のファイルパス： `./style.css`
- 期待されるリクエスト： `https://covid-19-act.jp/parenting-who/style.css`
- 末尾スラッシュなしのリクエスト： `https://covid-19-act.jp/style.css`

当初はドメインルートの netlify.toml ファイルでリダイレクト処理を設定しようと試みましたが、当プロジェクト全体の 200 Rewrite 設定のせいなのかうまくいきません。

そこで、 `<base>` 要素を使った方法で対象します。`<base>` 要素は記述があるだけでどんな環境でも作用してしまうので、ローカルビルドでは出力せず、本番ビルドでだけ吐かれるようにしています。

動作実績は `https://covid-19-act.jp/follow` で体感できます。

確認お願いいたします。